### PR TITLE
Updated defaults pr11

### DIFF
--- a/eessi/reframe/eessi-checks/applications/gromacs_check.py
+++ b/eessi/reframe/eessi-checks/applications/gromacs_check.py
@@ -57,15 +57,6 @@ class GROMACS_EESSI(gromacs_check):
                 # Invalid combination: a module without GPU support cannot compute non-bonded interactions on GPU
                 valid_systems = ''
 
-#             if is_cuda_module:
-#                 valid_systems = '+gpu'
-#                 if self.nb_impl == 'cpu':
-#                     valid_systems += ' +cpu'
-#             else:
-#                 valid_systems += '+cpu'
-#                 if self.nb_impl == 'gpu':
-#                     valid_systems = ''  # impossible combination
-
             if valid_systems:
                 self.valid_systems = [valid_systems]
 
@@ -89,29 +80,6 @@ class GROMACS_EESSI(gromacs_check):
         # Select one test for CI
         if self.benchmark_info[0] == 'HECBioSim/hEGFRDimer':
             self.tags.add('CI')
-
-#    # Skip testing for when nb_impl=gpu and this is not a GPU node
-#    @run_after('setup')
-#    def skip_nb_impl_gpu_on_cpu_nodes(self):
-#        self.skip_if(
-#            (self.nb_impl == 'gpu' and not utils.is_gpu_present(self)),
-#            "Skipping test variant with non-bonded interactions on GPUs, "
-#            f"as this partition ({self.current_partition.name}) does not have GPU nodes"
-#        )
-#
-#    # Sckip testing when nb_impl=gpu and this is not a GPU build of GROMACS
-#    @run_after('setup')
-#    def skip_nb_impl_gpu_on_non_cuda_builds(self):
-#        self.skip_if(
-#            (self.nb_impl == 'gpu' and not utils.is_cuda_required(self)),
-#            "Skipping test variant with non-bonded interactions on GPUs, "
-#            f"as this module ({self.module_name}) was not build with GPU support"
-#        )
-#
-#    # Skip testing GPU-based modules on CPU-based nodes
-#    @run_after('setup')
-#    def skip_gpu_test_on_cpu_nodes(self):
-#        hooks.skip_gpu_test_on_cpu_nodes(self)
 
     # Assign num_tasks, num_tasks_per_node and num_cpus_per_task automatically
     # based on current partition's num_cpus and gpus


### PR DESCRIPTION
I made the defaults for the partitions more explicit by listing all cases, rather than nesting if-statements. It resulted in another combination of module, `nb_impl` and partition that turned out to be completely 'valid', as mentioned in [this comment](https://github.com/EESSI/test-suite/pull/11#issuecomment-1430014386), so I think it's helpfull to have this more explicit.

Essentially it now says:
```
if is_cuda_module and self.nb_impl == 'gpu':
    valid_systems = '+gpu'
```
is the only valid combination for running `nb_impl == 'gpu'`, since that requires a CUDA-aware module, and a GPU partition,
```
elif self.nb_impl == 'cpu':
                # Non-bonded interactions on the CPU require partitions with 'cpu' feature
                # Note: making 'cpu' an explicit feature allows e.g. skipping CPU-based tests on GPU partitions

                valid_systems = '+cpu'
```
running with `nb_impl == 'cpu'` is valid with _any_ module (both CUDA aware and non-CUDA aware) and on any partition that identifies itself as having the `cpu` feature,
```
elif not is_cuda_module and self.nb_impl == 'gpu':
    valid_systems = ''
```
is simply invalid (you can't run on a GPU without a CUDA aware module) and should be filtered.

I think with this explicit, case-by-case logic, it'll also be easier to add new cases, e.g. if future GROMACS versions might support AMD GPUs etc, in which case `is_rocm_module and self.nb_impl == 'gpu'` might also become a valid case.