### PR TITLE
use separate partitions for 40GB and 80GB GPU nodes on Hortense + also add CPU-only partitions

### DIFF
--- a/eessi/reframe/config/config_ugent_hortense.py
+++ b/eessi/reframe/config/config_ugent_hortense.py
@@ -1,3 +1,8 @@
+# ReFrame configuration file for VSC Tier-1 Hortense
+# https://docs.vscentrum.be/en/latest/gent/tier1_hortense.html
+#
+# authors: Sam Moors (VUB-HPC), Kenneth Hoste (HPC-UGent)
+
 from reframe.core.backends import register_launcher
 from reframe.core.launchers import JobLauncher
 
@@ -43,11 +48,89 @@ site_configuration = {
             'modules_system': 'lmod',
             'partitions': [
                 {
-                    'name': 'gpu_rome_a100',
+                    'name': 'cpu_rome_256gb',
                     'scheduler': 'slurm',
-                    'access': [f'-A {account} --export=NONE --get-user-env=60L --partition=gpu_rome_a100'],
+                    'access': [f'-A {account} --export=NONE --get-user-env=60L --partition=cpu_rome'],
                     'environs': ['default'],
-                    'descr': 'gpu nodes',
+                    'descr': 'CPU nodes (AMD Rome, 256GiB RAM)',
+                    'max_jobs': 20,
+                    'launcher': 'mympirun',
+                    'modules': ['vsc-mympirun'],
+                    'processor': {
+                        'num_cpus': 128,
+                    },
+                    'features': [
+                        'cpu',
+                    ],
+                },
+                {
+                    'name': 'cpu_rome_512gb',
+                    'scheduler': 'slurm',
+                    'access': [f'-A {account} --export=NONE --get-user-env=60L --partition=cpu_rome_512'],
+                    'environs': ['default'],
+                    'descr': 'CPU nodes (AMD Rome, 512GiB RAM)',
+                    'max_jobs': 20,
+                    'launcher': 'mympirun',
+                    'modules': ['vsc-mympirun'],
+                    'processor': {
+                        'num_cpus': 128,
+                    },
+                    'features': [
+                        'cpu',
+                    ],
+                },
+                {
+                    'name': 'cpu_milan',
+                    'scheduler': 'slurm',
+                    'access': [f'-A {account} --export=NONE --get-user-env=60L --partition=cpu_milan'],
+                    'environs': ['default'],
+                    'descr': 'CPU nodes (AMD Milan, 256GiB RAM)',
+                    'max_jobs': 20,
+                    'launcher': 'mympirun',
+                    'modules': ['vsc-mympirun'],
+                    'processor': {
+                        'num_cpus': 128,
+                    },
+                    'features': [
+                        'cpu',
+                    ],
+                },
+                {
+                    'name': 'gpu_rome_a100_40gb',
+                    'scheduler': 'slurm',
+                    'access': [f'-A {account} --export=NONE --get-user-env=60L --partition=gpu_rome_a100_40'],
+                    'environs': ['default'],
+                    'descr': 'GPU nodes (A100 40GB)',
+                    'max_jobs': 20,
+                    'launcher': 'mympirun',
+                    'modules': ['vsc-mympirun'],
+                    'processor': {
+                        'num_cpus': 48,
+                    },
+                    'features': [
+                        'cpu',
+                        'gpu',
+                    ],
+                    'resources': [
+                        {
+                            'name': '_rfm_gpu',
+                            'options': ['--gpus-per-node={num_gpus_per_node}'],
+                        }
+                    ],
+                    'devices': [
+                        {
+                            'type': 'gpu',
+                            'num_devices': 4,
+                        }
+                    ],
+
+                },
+                {
+                    'name': 'gpu_rome_a100_80gb',
+                    'scheduler': 'slurm',
+                    'access': [f'-A {account} --export=NONE --get-user-env=60L --partition=gpu_rome_a100_80'],
+                    'environs': ['default'],
+                    'descr': 'GPU nodes (A100 80GB)',
                     'max_jobs': 20,
                     'launcher': 'mympirun',
                     'modules': ['vsc-mympirun'],


### PR DESCRIPTION
@smoors for https://github.com/EESSI/test-suite/pull/24

cc @laraPPr